### PR TITLE
fix: use correct `claude plugin install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Learn more about Daana and DMDL at [docs.daana.dev](https://docs.daana.dev).
 ## Installation
 
 ```bash
-claude plugin add https://github.com/mattiasthalen/daana-modeler
+claude plugin install https://github.com/mattiasthalen/daana-modeler
 ```
 
 ## Usage

--- a/docs/superpowers/plans/2026-03-14-readme-and-license.md
+++ b/docs/superpowers/plans/2026-03-14-readme-and-license.md
@@ -82,7 +82,7 @@ A Claude Code skill that interviews you to build DMDL model files.
 **As a Claude Code plugin** (recommended):
 
 ```bash
-claude plugin add https://github.com/mattiasthalen/daana-modeler
+claude plugin install https://github.com/mattiasthalen/daana-modeler
 ```
 
 **As a local skill:**

--- a/docs/superpowers/plans/2026-03-15-plugin-restructure.md
+++ b/docs/superpowers/plans/2026-03-15-plugin-restructure.md
@@ -573,7 +573,7 @@ Learn more about Daana and DMDL at [docs.daana.dev](https://docs.daana.dev).
 ## Installation
 
 ```bash
-claude plugin add https://github.com/mattiasthalen/daana-modeler
+claude plugin install https://github.com/mattiasthalen/daana-modeler
 ```
 
 ## Usage

--- a/docs/superpowers/specs/2026-03-15-plugin-restructure-design.md
+++ b/docs/superpowers/specs/2026-03-15-plugin-restructure-design.md
@@ -82,7 +82,7 @@ daana-modeler/
 }
 ```
 
-No custom component paths are needed. The `skills/` directory is the default discovery location and will be auto-discovered. The `references/` directory is not a plugin component — skills read its files directly via paths relative to the plugin root (e.g., `references/model-schema.md`). When installed via `claude plugin add`, the entire plugin directory is cached locally and relative paths resolve from the plugin root.
+No custom component paths are needed. The `skills/` directory is the default discovery location and will be auto-discovered. The `references/` directory is not a plugin component — skills read its files directly via paths relative to the plugin root (e.g., `references/model-schema.md`). When installed via `claude plugin install`, the entire plugin directory is cached locally and relative paths resolve from the plugin root.
 
 ## Skill Changes
 
@@ -136,7 +136,7 @@ The core interview flows, validation rules, and behavioral instructions within e
 - Update usage section: replace `/daana` with `/daana:model`, `/daana:map`, `/daana:query`.
 - Add brief description of each skill's purpose.
 - Remove the "As a local skill: Copy the `skills/daana/` directory..." fallback instruction — it no longer applies with the new structure.
-- Installation command remains `claude plugin add` (already correct).
+- Installation command remains `claude plugin install` (already correct).
 
 ## Issues Resolved
 


### PR DESCRIPTION
## Summary
- `claude plugin add` is not a valid CLI command — replaced with `claude plugin install` across all 4 files that referenced it
- Fixes installation instructions in README.md and related design/plan docs

## Test plan
- [ ] Run `claude plugin install https://github.com/mattiasthalen/daana-modeler` and confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)