### PR TITLE
fix: add marketplace.json and correct install instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "daana-modeler",
+  "owner": {
+    "name": "Mattias Thalén"
+  },
+  "plugins": [
+    {
+      "name": "daana",
+      "source": "./"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ daana-modeler is a Claude Code plugin for the Daana data platform. It provides t
 
 - **`.claude-plugin/`** — Plugin manifest
   - `plugin.json` — Plugin metadata (name: `daana`)
+  - `marketplace.json` — Marketplace catalog for plugin discovery
 - **`skills/model/`** — Model interview skill (`/daana:model`)
   - `SKILL.md` — Builds model.yaml via interactive interview
 - **`skills/map/`** — Mapping interview skill (`/daana:map`)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Learn more about Daana and DMDL at [docs.daana.dev](https://docs.daana.dev).
 ## Installation
 
 ```bash
-claude plugin install https://github.com/mattiasthalen/daana-modeler
+claude plugin marketplace add mattiasthalen/daana-modeler
+claude plugin install daana
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Added `.claude-plugin/marketplace.json` for plugin marketplace discovery
- Fixed install instructions in README — `claude plugin install` doesn't accept raw GitHub URLs; users must first add the repo as a marketplace, then install by plugin name
- Updated CLAUDE.md to document the new file

## Test plan
- [ ] Run `claude plugin marketplace add mattiasthalen/daana-modeler` and verify marketplace is added
- [ ] Run `claude plugin install daana` and verify plugin installs successfully
- [ ] Verify `/daana:model`, `/daana:map`, `/daana:query` skills are available after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)