### PR TITLE
fix: prefix skill names with daana- to avoid command clashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ daana-modeler is a Claude Code plugin for the Daana data platform. It provides t
 - **`.claude-plugin/`** — Plugin manifest
   - `plugin.json` — Plugin metadata (name: `daana`)
   - `marketplace.json` — Marketplace catalog for plugin discovery
-- **`skills/model/`** — Model interview skill (`/daana:model`)
+- **`skills/model/`** — Model interview skill (`/daana-model`)
   - `SKILL.md` — Builds model.yaml via interactive interview
-- **`skills/map/`** — Mapping interview skill (`/daana:map`)
+- **`skills/map/`** — Mapping interview skill (`/daana-map`)
   - `SKILL.md` — Builds mapping files via interactive interview
-- **`skills/query/`** — Data query skill (`/daana:query`)
+- **`skills/query/`** — Data query skill (`/daana-query`)
   - `SKILL.md` — Answers natural language questions about data via live SQL
 - **`references/`** — Shared DMDL schema, examples, and source schema formats
 - **`docs/superpowers/specs/`** — Design specifications

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A Claude Code plugin that interviews you to build DMDL model and mapping files, 
 
 daana-modeler is a plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that provides three skills:
 
-- **`/daana:model`** — Interactive interview to define business entities, attributes, and relationships, generating a valid DMDL `model.yaml` file.
-- **`/daana:map`** — Interactive interview to map source tables to model entities, generating DMDL mapping files.
-- **`/daana:query`** — Natural language data agent that answers questions about your Focal-based Daana data warehouse via live SQL queries.
+- **`/daana-model`** — Interactive interview to define business entities, attributes, and relationships, generating a valid DMDL `model.yaml` file.
+- **`/daana-map`** — Interactive interview to map source tables to model entities, generating DMDL mapping files.
+- **`/daana-query`** — Natural language data agent that answers questions about your Focal-based Daana data warehouse via live SQL queries.
 
 Learn more about Daana and DMDL at [docs.daana.dev](https://docs.daana.dev).
 
@@ -26,9 +26,9 @@ claude plugin install daana
 
 Run any of the skills as slash commands in Claude Code:
 
-- `/daana:model` — Start building your data model
-- `/daana:map` — Create source-to-model mappings
-- `/daana:query` — Query your data warehouse
+- `/daana-model` — Start building your data model
+- `/daana-map` — Create source-to-model mappings
+- `/daana-query` — Query your data warehouse
 
 Each skill can hand you over to the next logical step when it completes.
 

--- a/skills/map/SKILL.md
+++ b/skills/map/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: map
+name: daana-map
 description: Interview-driven DMDL mapping file builder. Maps source tables to model entities with transformation expressions.
 ---
 
@@ -239,8 +239,8 @@ Always use `default_mapping_group`. Do not ask the user about this.
 If yes, loop back to Phase 1.
 
 If all entities are mapped (or the user declines), offer handover:
-*"All done with mappings! Want to explore your data with live queries? I can hand you over to `/daana:query`."*
-If the user accepts, invoke `/daana:query` using the Skill tool.
+*"All done with mappings! Want to explore your data with live queries? I can hand you over to `/daana-query`."*
+If the user accepts, invoke `/daana-query` using the Skill tool.
 
 ---
 

--- a/skills/model/SKILL.md
+++ b/skills/model/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: model
+name: daana-model
 description: Interview-driven DMDL model.yaml builder. Walks users through defining entities, attributes, and relationships.
 ---
 
@@ -203,8 +203,8 @@ After each entity is written:
    - Otherwise apply built-in validation rules from `references/model-schema.md`.
 
 5. **Suggest next steps and offer handover:**
-   *"Your model is ready! Want to create source mappings for your entities? I can hand you over to `/daana:map`."*
-   If the user accepts, invoke `/daana:map` using the Skill tool.
+   *"Your model is ready! Want to create source mappings for your entities? I can hand you over to `/daana-map`."*
+   If the user accepts, invoke `/daana-map` using the Skill tool.
 
 ---
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: query
+name: daana-query
 description: Data agent that answers natural language questions about Focal-based Daana data warehouses via live SQL queries.
 ---
 
@@ -11,7 +11,7 @@ You are a data analyst fluent in the Focal framework. You think in entities, att
 
 - **Read-only data access only.** You query data — you never modify it.
 - Never generate or execute INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE, or any other DDL/DML.
-- Never create or edit DMDL model or mapping files — that is the job of `/daana:model` and `/daana:map`.
+- Never create or edit DMDL model or mapping files — that is the job of `/daana-model` and `/daana-map`.
 - Never make assumptions about business logic not present in the discovered metadata.
 
 ## Adaptive Behavior
@@ -203,5 +203,5 @@ There is no explicit wrap-up phase — the session ends naturally when the user 
 ## Handover
 
 If during the conversation you detect unmapped entities (e.g., the user asks about an entity that has no data in the warehouse), suggest:
-*"It looks like ENTITY isn't mapped yet — want to set up source mappings with `/daana:map`?"*
-If the user accepts, invoke `/daana:map` using the Skill tool.
+*"It looks like ENTITY isn't mapped yet — want to set up source mappings with `/daana-map`?"*
+If the user accepts, invoke `/daana-map` using the Skill tool.


### PR DESCRIPTION
## Summary
- Renamed skill frontmatter names from `model`/`map`/`query` to `daana-model`/`daana-map`/`daana-query`
- Plugin skills aren't auto-namespaced — the `name` field in SKILL.md becomes the slash command directly
- Updated all cross-references in skill files, README, and CLAUDE.md

## Test plan
- [ ] Install plugin and verify skills appear as `/daana-model`, `/daana-map`, `/daana-query`
- [ ] Verify skill handover references work (e.g., model → map → query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)