### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "daana",
   "description": "Interview-driven DMDL model and mapping builder for the Daana data platform",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Mattias Thalén"
   },


### PR DESCRIPTION
## Summary
- Bump plugin version from 1.0.0 to 1.1.0 for query skill improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)