### PR TITLE
feat: add adventure-works-ddw external reference

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "daana",
   "description": "Interview-driven DMDL model and mapping builder for the Daana data platform",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": {
     "name": "Mattias Thalén"
   },

--- a/external.lock
+++ b/external.lock
@@ -8,7 +8,12 @@
     {
       "name": "daana-cli",
       "url": "git@github.com:daana-code/daana-cli.git",
-      "commit": "1b9a55be4d69597c5ac2ec375c88c07130da7513"
+      "commit": "c3d510ef8f01ebb7b82e130ef43cb405f989c60b"
+    },
+    {
+      "name": "adventure-works-ddw",
+      "url": "git@github.com:mattiasthalen/adventure-works-ddw.git",
+      "commit": "6d41203eb5bdd46d2a0f2e59a32e6059cb8a2907"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `adventure-works-ddw` demo repo to `external.lock` for testing
- Update `daana-cli` pin to latest main commit
- Bump version to 1.11.0

## Test plan
- [ ] Run `scripts/setup-external.sh` and verify all three repos clone/checkout correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)