### PR TITLE
fix: use Type 2 dedup for relationship CTEs in USS peripherals

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "daana",
   "description": "Interview-driven DMDL model and mapping builder for the Daana data platform",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "author": {
     "name": "Mattias Thalén"
   },

--- a/docs/superpowers/plans/2026-03-27-uss-peripheral-relationship-type2.md
+++ b/docs/superpowers/plans/2026-03-27-uss-peripheral-relationship-type2.md
@@ -1,0 +1,622 @@
+# USS Peripheral Relationship Type 2 Dedup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix relationship CTEs in USS peripheral views to use Type 2 dedup with carry-forward instead of snapshot dedup, so relationship FKs reflect historical state at each effective timestamp.
+
+**Architecture:** Each peripheral's relationship CTEs change from snapshot dedup (latest-only) to Type 2 dedup (one row per EFF_TMSTP). Relationship EFF_TMSTPs merge into the timeline spine. Relationship FKs get carry-forward windows in the pivoted CTE, eliminating separate LEFT JOINs in peripheral_final.
+
+**Tech Stack:** PostgreSQL SQL, USS skill reference patterns
+
+**Design spec:** `docs/superpowers/specs/2026-03-27-uss-peripheral-relationship-type2-design.md`
+
+---
+
+## Notes
+
+- `store.sql` is listed in the issue but has NO relationship CTEs — it is NOT affected.
+- There are no automated tests; verification is visual inspection of SQL correctness.
+- All SQL file tasks are independent and can run in parallel.
+
+## Transformation Pattern
+
+Every affected file applies the same 4-step transformation:
+
+### A. Relationship CTE: Snapshot -> Type 2 Dedup
+
+**Before:**
+```sql
+ranked_{rel_table} AS (
+    SELECT
+        {SOURCE}_KEY,
+        {TARGET}_KEY,
+        RANK() OVER (
+            PARTITION BY {SOURCE}_KEY
+            ORDER BY EFF_TMSTP DESC, VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.{REL_TABLE}
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = {N}
+),
+rel_{alias} AS (
+    SELECT {SOURCE}_KEY, {TARGET}_KEY
+    FROM ranked_{rel_table}
+    WHERE rnk = 1
+)
+```
+
+**After:**
+```sql
+ranked_{rel_table} AS (
+    SELECT
+        {SOURCE}_KEY,
+        {TARGET}_KEY,
+        EFF_TMSTP,
+        RANK() OVER (
+            PARTITION BY {SOURCE}_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.{REL_TABLE}
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = {N}
+),
+rel_{alias} AS (
+    SELECT {SOURCE}_KEY, {TARGET}_KEY, EFF_TMSTP
+    FROM ranked_{rel_table}
+    WHERE rnk = 1
+)
+```
+
+Changes: (1) add `EFF_TMSTP` to SELECT, (2) add `EFF_TMSTP` to PARTITION BY, (3) remove `EFF_TMSTP DESC` from ORDER BY, (4) add `EFF_TMSTP` to rel output.
+
+### B. Timeline CTE: Add UNION for Each Relationship
+
+**Before:**
+```sql
+timeline AS (
+    SELECT DISTINCT {ENTITY}_KEY, EFF_TMSTP
+    FROM deduped
+)
+```
+
+**After:**
+```sql
+timeline AS (
+    SELECT DISTINCT {ENTITY}_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT {SOURCE}_KEY, EFF_TMSTP
+    FROM rel_{alias_1}
+    UNION
+    SELECT DISTINCT {SOURCE}_KEY, EFF_TMSTP
+    FROM rel_{alias_2}
+    -- ... one UNION per relationship
+)
+```
+
+### C. Pivoted CTE: Add Relationship FK Carry-Forward + LEFT JOINs
+
+Add to the SELECT list (after descriptor columns):
+```sql
+MAX(r_{alias}.{TARGET}_KEY) OVER (
+    PARTITION BY t.{ENTITY}_KEY
+    ORDER BY t.EFF_TMSTP
+    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+) AS {TARGET}_KEY
+```
+
+Add to the FROM clause (after the deduped LEFT JOIN):
+```sql
+LEFT JOIN rel_{alias} r_{alias}
+    ON t.{SOURCE}_KEY = r_{alias}.{SOURCE}_KEY AND t.EFF_TMSTP = r_{alias}.EFF_TMSTP
+```
+
+### D. peripheral_final: Remove Separate Relationship JOINs
+
+- Remove all `LEFT JOIN rel_* ...` from peripheral_final
+- Change `r{alias}.{TARGET}_KEY` references to `p.{TARGET}_KEY` (now from pivoted_deduped)
+- For aliased columns (e.g., `rba.ADDRESS_KEY AS BILL_TO_ADDRESS_KEY`), the alias moves into the pivoted CTE
+
+---
+
+## Task 1: Fix customer.sql
+
+**Can run in parallel with:** Tasks 2-8
+
+**File:** `uss/customer.sql`
+**Relationships:** 3 (person TYPE_KEY=65, sales_territory TYPE_KEY=33, store TYPE_KEY=63)
+
+**Step 1: Update relationship CTEs**
+
+Apply pattern A to all 3 relationship CTEs:
+
+```sql
+-- Resolve relationships: CUSTOMER -> PERSON (TYPE_KEY=65)
+ranked_customer_person_x AS (
+    SELECT
+        CUSTOMER_KEY,
+        PERSON_KEY,
+        EFF_TMSTP,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_PERSON_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 65
+),
+rel_person AS (
+    SELECT CUSTOMER_KEY, PERSON_KEY, EFF_TMSTP
+    FROM ranked_customer_person_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: CUSTOMER -> SALES_TERRITORY (TYPE_KEY=33)
+ranked_customer_sales_territory_x AS (
+    SELECT
+        CUSTOMER_KEY,
+        SALES_TERRITORY_KEY,
+        EFF_TMSTP,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_SALES_TERRITORY_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 33
+),
+rel_sales_territory AS (
+    SELECT CUSTOMER_KEY, SALES_TERRITORY_KEY, EFF_TMSTP
+    FROM ranked_customer_sales_territory_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: CUSTOMER -> STORE (TYPE_KEY=63)
+ranked_customer_store_x AS (
+    SELECT
+        CUSTOMER_KEY,
+        STORE_KEY,
+        EFF_TMSTP,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_STORE_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 63
+),
+rel_store AS (
+    SELECT CUSTOMER_KEY, STORE_KEY, EFF_TMSTP
+    FROM ranked_customer_store_x
+    WHERE rnk = 1
+),
+```
+
+**Step 2: Move relationship CTEs before timeline**
+
+The relationship CTEs must be defined BEFORE the timeline CTE (since timeline references them). Move them to after `deduped`.
+
+**Step 3: Update timeline CTE**
+
+```sql
+timeline AS (
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM rel_person
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM rel_sales_territory
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM rel_store
+),
+```
+
+**Step 4: Update pivoted CTE**
+
+```sql
+pivoted AS (
+    SELECT
+        t.CUSTOMER_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 89 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS customer_account_number,
+        MAX(rp.PERSON_KEY) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PERSON_KEY,
+        MAX(rst.SALES_TERRITORY_KEY) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SALES_TERRITORY_KEY,
+        MAX(rs.STORE_KEY) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS STORE_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.CUSTOMER_KEY = d.CUSTOMER_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_person rp ON t.CUSTOMER_KEY = rp.CUSTOMER_KEY AND t.EFF_TMSTP = rp.EFF_TMSTP
+    LEFT JOIN rel_sales_territory rst ON t.CUSTOMER_KEY = rst.CUSTOMER_KEY AND t.EFF_TMSTP = rst.EFF_TMSTP
+    LEFT JOIN rel_store rs ON t.CUSTOMER_KEY = rs.CUSTOMER_KEY AND t.EFF_TMSTP = rs.EFF_TMSTP
+),
+```
+
+**Step 5: Update peripheral_final**
+
+Remove `LEFT JOIN rel_*` lines. Reference FK columns from `p.` instead of `rp.`/`rst.`/`rs.`:
+
+```sql
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.CUSTOMER_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.CUSTOMER_KEY,
+        p.customer_account_number,
+        p.PERSON_KEY,
+        p.SALES_TERRITORY_KEY,
+        p.STORE_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.CUSTOMER_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.CUSTOMER_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+```
+
+**Step 6: Commit**
+
+```bash
+git add uss/customer.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in customer peripheral"
+```
+
+---
+
+## Task 2: Fix employee.sql
+
+**Can run in parallel with:** Tasks 1, 3-8
+
+**File:** `uss/employee.sql`
+**Relationships:** 1 (person TYPE_KEY=83)
+
+Apply the same transformation pattern (A-D) with these specifics:
+
+**Step 1: Update ranked_employee_person_x** — add `EFF_TMSTP` to SELECT/PARTITION BY, remove from ORDER BY. Update `rel_person` to include `EFF_TMSTP`.
+
+**Step 2: Move relationship CTEs before timeline.**
+
+**Step 3: Update timeline:**
+```sql
+timeline AS (
+    SELECT DISTINCT EMPLOYEE_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT EMPLOYEE_KEY, EFF_TMSTP
+    FROM rel_person
+),
+```
+
+**Step 4: Add to pivoted CTE** (after last descriptor column):
+```sql
+        MAX(rp.PERSON_KEY) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PERSON_KEY
+```
+Add LEFT JOIN: `LEFT JOIN rel_person rp ON t.EMPLOYEE_KEY = rp.EMPLOYEE_KEY AND t.EFF_TMSTP = rp.EFF_TMSTP`
+
+**Step 5: Update peripheral_final** — remove `LEFT JOIN rel_person rp`, change `rp.PERSON_KEY` to `p.PERSON_KEY`.
+
+**Step 6: Commit**
+```bash
+git add uss/employee.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in employee peripheral"
+```
+
+---
+
+## Task 3: Fix sales_person.sql
+
+**Can run in parallel with:** Tasks 1-2, 4-8
+
+**File:** `uss/sales_person.sql`
+**Relationships:** 2 (employee TYPE_KEY=62, sales_territory TYPE_KEY=66)
+
+Apply transformation pattern (A-D):
+
+**Step 1:** Update both ranked CTEs + rel CTEs with EFF_TMSTP.
+
+**Step 2:** Move relationship CTEs before timeline.
+
+**Step 3:** Timeline unions rel_employee + rel_sales_territory.
+
+**Step 4:** Add carry-forward for EMPLOYEE_KEY and SALES_TERRITORY_KEY in pivoted. Add 2 LEFT JOINs.
+
+**Step 5:** Remove `LEFT JOIN rel_employee re` and `LEFT JOIN rel_sales_territory rst` from peripheral_final. Change `re.EMPLOYEE_KEY` to `p.EMPLOYEE_KEY`, `rst.SALES_TERRITORY_KEY` to `p.SALES_TERRITORY_KEY`.
+
+**Step 6: Commit**
+```bash
+git add uss/sales_person.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in sales_person peripheral"
+```
+
+---
+
+## Task 4: Fix vendor.sql
+
+**Can run in parallel with:** Tasks 1-3, 5-8
+
+**File:** `uss/vendor.sql`
+**Relationships:** 1 (person TYPE_KEY=91)
+
+Apply transformation pattern (A-D):
+
+**Step 1:** Update ranked_vendor_person_x + rel_person with EFF_TMSTP.
+
+**Step 2:** Move relationship CTEs before timeline.
+
+**Step 3:** Timeline unions rel_person.
+
+**Step 4:** Add carry-forward for PERSON_KEY in pivoted. Add LEFT JOIN.
+
+**Step 5:** Remove `LEFT JOIN rel_person rp` from peripheral_final. Change `rp.PERSON_KEY` to `p.PERSON_KEY`.
+
+**Step 6: Commit**
+```bash
+git add uss/vendor.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in vendor peripheral"
+```
+
+---
+
+## Task 5: Fix sales_order.sql
+
+**Can run in parallel with:** Tasks 1-4, 6-8
+
+**File:** `uss/sales_order.sql`
+**Relationships:** 5 (customer TYPE_KEY=7, bill_address TYPE_KEY=189, ship_address TYPE_KEY=190, sales_person TYPE_KEY=117, sales_territory TYPE_KEY=21)
+
+**Special:** Two ADDRESS relationships with aliases (BILL_TO_ADDRESS_KEY, SHIP_TO_ADDRESS_KEY).
+
+Apply transformation pattern (A-D):
+
+**Step 1:** Update all 5 ranked CTEs + rel CTEs with EFF_TMSTP.
+
+**Step 2:** Move all relationship CTEs before timeline.
+
+**Step 3:** Timeline unions all 5 rel CTEs.
+
+**Step 4:** Add carry-forward for all 5 FK columns in pivoted. For the address relationships, use aliases in the carry-forward:
+```sql
+        MAX(rba.ADDRESS_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS BILL_TO_ADDRESS_KEY,
+        MAX(rsa.ADDRESS_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SHIP_TO_ADDRESS_KEY,
+```
+
+Add 5 LEFT JOINs to pivoted.
+
+**Step 5:** Remove all 5 `LEFT JOIN rel_*` from peripheral_final. Change all alias references to `p.`:
+- `rc.CUSTOMER_KEY` -> `p.CUSTOMER_KEY`
+- `rba.ADDRESS_KEY AS BILL_TO_ADDRESS_KEY` -> `p.BILL_TO_ADDRESS_KEY`
+- `rsa.ADDRESS_KEY AS SHIP_TO_ADDRESS_KEY` -> `p.SHIP_TO_ADDRESS_KEY`
+- `rsp.SALES_PERSON_KEY` -> `p.SALES_PERSON_KEY`
+- `rst.SALES_TERRITORY_KEY` -> `p.SALES_TERRITORY_KEY`
+
+**Step 6: Commit**
+```bash
+git add uss/sales_order.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in sales_order peripheral"
+```
+
+---
+
+## Task 6: Fix sales_order_detail.sql
+
+**Can run in parallel with:** Tasks 1-5, 7-8
+
+**File:** `uss/sales_order_detail.sql`
+**Relationships:** 3 (sales_order TYPE_KEY=48, product TYPE_KEY=20, special_offer TYPE_KEY=3)
+
+Apply transformation pattern (A-D):
+
+**Step 1:** Update all 3 ranked CTEs + rel CTEs with EFF_TMSTP.
+
+**Step 2:** Move relationship CTEs before timeline.
+
+**Step 3:** Timeline unions all 3 rel CTEs.
+
+**Step 4:** Add carry-forward for SALES_ORDER_KEY, PRODUCT_KEY, SPECIAL_OFFER_KEY. Add 3 LEFT JOINs.
+
+**Step 5:** Remove `LEFT JOIN rel_*` from peripheral_final. Change:
+- `rso.SALES_ORDER_KEY` -> `p.SALES_ORDER_KEY`
+- `rpd.PRODUCT_KEY` -> `p.PRODUCT_KEY`
+- `rspo.SPECIAL_OFFER_KEY` -> `p.SPECIAL_OFFER_KEY`
+
+**Step 6: Commit**
+```bash
+git add uss/sales_order_detail.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in sales_order_detail peripheral"
+```
+
+---
+
+## Task 7: Fix purchase_order.sql
+
+**Can run in parallel with:** Tasks 1-6, 8
+
+**File:** `uss/purchase_order.sql`
+**Relationships:** 2 (employee TYPE_KEY=30, vendor TYPE_KEY=12)
+
+Apply transformation pattern (A-D):
+
+**Step 1:** Update both ranked CTEs + rel CTEs with EFF_TMSTP.
+
+**Step 2:** Move relationship CTEs before timeline.
+
+**Step 3:** Timeline unions rel_employee + rel_vendor.
+
+**Step 4:** Add carry-forward for EMPLOYEE_KEY and VENDOR_KEY. Add 2 LEFT JOINs.
+
+**Step 5:** Remove `LEFT JOIN rel_*` from peripheral_final. Change:
+- `re.EMPLOYEE_KEY` -> `p.EMPLOYEE_KEY`
+- `rv.VENDOR_KEY` -> `p.VENDOR_KEY`
+
+**Step 6: Commit**
+```bash
+git add uss/purchase_order.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in purchase_order peripheral"
+```
+
+---
+
+## Task 8: Fix work_order.sql
+
+**Can run in parallel with:** Tasks 1-7
+
+**File:** `uss/work_order.sql`
+**Relationships:** 1 (product TYPE_KEY=74)
+
+Apply transformation pattern (A-D):
+
+**Step 1:** Update ranked_wo_product_x + rel_product with EFF_TMSTP.
+
+**Step 2:** Move relationship CTEs before timeline.
+
+**Step 3:** Timeline unions rel_product.
+
+**Step 4:** Add carry-forward for PRODUCT_KEY. Add LEFT JOIN.
+
+**Step 5:** Remove `LEFT JOIN rel_product rpd` from peripheral_final. Change `rpd.PRODUCT_KEY` to `p.PRODUCT_KEY`.
+
+**Step 6: Commit**
+```bash
+git add uss/work_order.sql
+git commit -m "fix: use Type 2 dedup for relationship CTEs in work_order peripheral"
+```
+
+---
+
+## Task 9: Update uss-patterns.md
+
+**Can run in parallel with:** Tasks 1-8
+
+**File:** `skills/uss/references/uss-patterns.md`
+
+The current patterns doc only documents the snapshot relationship pattern (used in the bridge). Since peripherals now use a different pattern, we need to document the peripheral-specific Type 2 relationship pattern.
+
+**Step 1:** After the existing "Step 2: Resolve Relationships" section (which is bridge-specific), add a note clarifying this is the bridge pattern. Then add a new subsection for the peripheral relationship pattern:
+
+Add after the existing relationship pattern section (~line 355), a new section:
+
+```markdown
+### Peripheral Relationship Resolution
+
+> **Important:** The snapshot relationship pattern above applies to the **bridge** only. Peripherals use Type 2 dedup for relationships, matching how they handle descriptors.
+
+In peripherals, relationships must preserve history. The pattern:
+
+1. **Dedup per EFF_TMSTP** (not snapshot):
+
+    ```sql
+    ranked_{rel_table} AS (
+        SELECT
+            {source_attr_name},
+            {target_attr_name},
+            EFF_TMSTP,
+            RANK() OVER (
+                PARTITION BY {source_attr_name}, EFF_TMSTP
+                ORDER BY VER_TMSTP DESC
+            ) AS rnk
+        FROM {source_schema}.{relationship_table}
+        WHERE ROW_ST = 'Y'
+          AND TYPE_KEY = {rel_type_key}
+    ),
+    {rel_alias} AS (
+        SELECT
+            {source_attr_name},
+            {target_attr_name},
+            EFF_TMSTP
+        FROM ranked_{rel_table}
+        WHERE rnk = 1
+    )
+    ```
+
+2. **Merge into timeline spine** — UNION relationship EFF_TMSTPs with descriptor EFF_TMSTPs:
+
+    ```sql
+    timeline AS (
+        SELECT DISTINCT {entity}_KEY, EFF_TMSTP
+        FROM deduped
+        UNION
+        SELECT DISTINCT {source_attr_name}, EFF_TMSTP
+        FROM {rel_alias_1}
+        UNION
+        SELECT DISTINCT {source_attr_name}, EFF_TMSTP
+        FROM {rel_alias_2}
+    )
+    ```
+
+3. **Carry-forward** — join relationships to timeline and apply window:
+
+    ```sql
+    MAX(r.{target_attr_name}) OVER (
+        PARTITION BY t.{entity}_KEY
+        ORDER BY t.EFF_TMSTP
+        RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS {target_attr_name}
+    ```
+
+    With LEFT JOIN:
+    ```sql
+    LEFT JOIN {rel_alias} r
+        ON t.{source_attr_name} = r.{source_attr_name}
+        AND t.EFF_TMSTP = r.EFF_TMSTP
+    ```
+
+This ensures relationship FKs reflect the relationship as-of each effective timestamp, not just the latest.
+```
+
+**Step 2: Commit**
+```bash
+git add skills/uss/references/uss-patterns.md
+git commit -m "docs: document Type 2 peripheral relationship pattern in uss-patterns"
+```
+
+---
+
+## Task 10: Version bump + final commit
+
+**Depends on:** Tasks 1-9
+
+**File:** `.claude-plugin/plugin.json`
+
+**Step 1:** Read current version, bump patch.
+
+**Step 2: Commit**
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "chore: bump version to {new_version}"
+```
+
+**Step 3: Push**
+```bash
+git push -u origin fix/uss-peripheral-relationship-dedup
+```

--- a/docs/superpowers/specs/2026-03-27-uss-peripheral-relationship-type2-design.md
+++ b/docs/superpowers/specs/2026-03-27-uss-peripheral-relationship-type2-design.md
@@ -1,0 +1,110 @@
+# USS Peripheral Relationship Type 2 Dedup
+
+**Issue:** #55
+**Date:** 2026-03-27
+
+## Problem
+
+Peripheral views with relationships use snapshot dedup for relationship CTEs:
+
+```sql
+PARTITION BY CUSTOMER_KEY
+ORDER BY EFF_TMSTP DESC, VER_TMSTP DESC
+```
+
+This always resolves to the latest relationship, discarding history. Descriptor CTEs in the same file correctly use Type 2 dedup:
+
+```sql
+PARTITION BY CUSTOMER_KEY, TYPE_KEY, EFF_TMSTP
+ORDER BY VER_TMSTP DESC
+```
+
+Result: all historical peripheral rows show the *current* relationship, not the relationship as-of each `effective_from` point.
+
+## Approach: Unified Timeline with Carry-Forward
+
+Treat relationships identically to descriptors: dedup per `EFF_TMSTP`, merge into the timeline spine, and carry-forward via window functions.
+
+### Change 1: Relationship CTE Dedup
+
+From snapshot (one row per entity):
+```sql
+RANK() OVER (
+    PARTITION BY CUSTOMER_KEY
+    ORDER BY EFF_TMSTP DESC, VER_TMSTP DESC
+) AS rnk
+```
+
+To Type 2 (one row per entity per EFF_TMSTP):
+```sql
+RANK() OVER (
+    PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+    ORDER BY VER_TMSTP DESC
+) AS rnk
+```
+
+Expose `EFF_TMSTP` in the output of the rel CTE.
+
+### Change 2: Timeline Spine Merge
+
+From descriptors only:
+```sql
+timeline AS (
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP FROM deduped
+)
+```
+
+To descriptors + relationships:
+```sql
+timeline AS (
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP FROM deduped
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP FROM rel_person
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP FROM rel_sales_territory
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP FROM rel_store
+)
+```
+
+### Change 3: Carry-Forward for Relationship FKs
+
+Join relationship CTEs to the timeline spine in the `pivoted` CTE (alongside descriptors), and apply the same carry-forward window:
+
+```sql
+MAX(rp.PERSON_KEY) OVER (
+    PARTITION BY t.CUSTOMER_KEY
+    ORDER BY t.EFF_TMSTP
+    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+) AS PERSON_KEY
+```
+
+With LEFT JOINs:
+```sql
+LEFT JOIN rel_person rp
+    ON t.CUSTOMER_KEY = rp.CUSTOMER_KEY AND t.EFF_TMSTP = rp.EFF_TMSTP
+```
+
+### Change 4: Simplify peripheral_final
+
+Remove separate `LEFT JOIN rel_*` from `peripheral_final` — everything is already resolved in `pivoted_deduped`.
+
+## Affected Files
+
+### SQL files (9 peripherals):
+- `uss/customer.sql`
+- `uss/employee.sql`
+- `uss/purchase_order.sql`
+- `uss/sales_order.sql`
+- `uss/sales_order_detail.sql`
+- `uss/sales_person.sql`
+- `uss/store.sql`
+- `uss/vendor.sql`
+- `uss/work_order.sql`
+
+### Reference patterns:
+- `skills/uss/references/uss-patterns.md` — update peripheral relationship pattern documentation
+
+## Non-Goals
+
+- Bridge relationship resolution is out of scope (bridge uses snapshot dedup intentionally, resolving against peripheral `effective_from`/`effective_to` via point-in-time joins).

--- a/skills/uss/references/uss-patterns.md
+++ b/skills/uss/references/uss-patterns.md
@@ -275,6 +275,71 @@ LEFT JOIN uss.customer c ON b._key__customer = c._peripheral_key
 LEFT JOIN uss.product p ON b._key__product = p._peripheral_key
 ```
 
+### Peripheral Relationship Resolution
+
+Peripherals use Type 2 dedup for relationships, matching how they handle descriptors. This ensures relationship FKs reflect the relationship as-of each effective timestamp.
+
+**1. Dedup per EFF_TMSTP** (not snapshot):
+
+```sql
+ranked_{rel_table} AS (
+    SELECT
+        {source_attr_name},
+        {target_attr_name},
+        EFF_TMSTP,
+        RANK() OVER (
+            PARTITION BY {source_attr_name}, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM {source_schema}.{relationship_table}
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = {rel_type_key}
+),
+{rel_alias} AS (
+    SELECT
+        {source_attr_name},
+        {target_attr_name},
+        EFF_TMSTP
+    FROM ranked_{rel_table}
+    WHERE rnk = 1
+)
+```
+
+**2. Merge into timeline spine** — UNION relationship EFF_TMSTPs with descriptor EFF_TMSTPs:
+
+```sql
+timeline AS (
+    SELECT DISTINCT {entity}_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT {source_attr_name}, EFF_TMSTP
+    FROM {rel_alias_1}
+    UNION
+    SELECT DISTINCT {source_attr_name}, EFF_TMSTP
+    FROM {rel_alias_2}
+)
+```
+
+**3. Carry-forward in pivoted CTE** — join relationships to timeline and apply the same window function used for descriptors:
+
+```sql
+MAX(r.{target_attr_name}) OVER (
+    PARTITION BY t.{entity}_KEY
+    ORDER BY t.EFF_TMSTP
+    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+) AS {target_attr_name}
+```
+
+With LEFT JOIN:
+
+```sql
+LEFT JOIN {rel_alias} r
+    ON t.{source_attr_name} = r.{source_attr_name}
+    AND t.EFF_TMSTP = r.EFF_TMSTP
+```
+
+**4. No separate joins in peripheral_final** — relationship FKs are already resolved in the pivoted CTE via carry-forward, so `peripheral_final` only references `p.{target_attr_name}` from `pivoted_deduped`.
+
 ## Bridge Pattern — Event-Grain, Snapshot
 
 The bridge UNION ALLs rows from **ALL entities** — both bridge sources and peripherals. Every entity in the USS participates in the bridge, making each entity both a fact (contributing rows) and a dimension (joinable via FK). Each entity contributes:
@@ -353,6 +418,8 @@ ranked_{rel_table} AS (
 ```
 
 **Fan-out prevention:** Only include relationships where the bridge source entity is on the `FOCAL01_KEY` side (many) and the peripheral is on the `FOCAL02_KEY` side (one). This ensures M:1 only — no fan-out. If an entity appears on `FOCAL01_KEY` of multiple relationships to the same entity, those are different relationship types (different TYPE_KEYs) and each should be a separate join.
+
+> **Bridge vs. Peripheral relationship resolution:** The snapshot pattern above applies to the **bridge** only, where relationships resolve to the latest FK for joining against peripheral `effective_from`/`effective_to`. Peripherals use Type 2 dedup for relationships — see [Peripheral Relationship Resolution](#peripheral-relationship-resolution) below.
 
 ### Step 3: Join Descriptors + Relationships
 

--- a/uss/customer.sql
+++ b/uss/customer.sql
@@ -1,0 +1,151 @@
+CREATE OR REPLACE VIEW uss.customer AS
+WITH ranked AS (
+    SELECT
+        CUSTOMER_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_STR,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: CUSTOMER -> PERSON (TYPE_KEY=65)
+ranked_customer_person_x AS (
+    SELECT
+        CUSTOMER_KEY,
+        EFF_TMSTP,
+        PERSON_KEY,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_PERSON_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 65
+),
+rel_person AS (
+    SELECT CUSTOMER_KEY, EFF_TMSTP, PERSON_KEY
+    FROM ranked_customer_person_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: CUSTOMER -> SALES_TERRITORY (TYPE_KEY=33)
+ranked_customer_sales_territory_x AS (
+    SELECT
+        CUSTOMER_KEY,
+        EFF_TMSTP,
+        SALES_TERRITORY_KEY,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_SALES_TERRITORY_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 33
+),
+rel_sales_territory AS (
+    SELECT CUSTOMER_KEY, EFF_TMSTP, SALES_TERRITORY_KEY
+    FROM ranked_customer_sales_territory_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: CUSTOMER -> STORE (TYPE_KEY=63)
+ranked_customer_store_x AS (
+    SELECT
+        CUSTOMER_KEY,
+        EFF_TMSTP,
+        STORE_KEY,
+        RANK() OVER (
+            PARTITION BY CUSTOMER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.CUSTOMER_STORE_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 63
+),
+rel_store AS (
+    SELECT CUSTOMER_KEY, EFF_TMSTP, STORE_KEY
+    FROM ranked_customer_store_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM rel_person
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM rel_sales_territory
+    UNION
+    SELECT DISTINCT CUSTOMER_KEY, EFF_TMSTP
+    FROM rel_store
+),
+pivoted AS (
+    SELECT
+        t.CUSTOMER_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 89 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS customer_account_number,
+        MAX(r_person.PERSON_KEY) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PERSON_KEY,
+        MAX(r_sales_territory.SALES_TERRITORY_KEY) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SALES_TERRITORY_KEY,
+        MAX(r_store.STORE_KEY) OVER (
+            PARTITION BY t.CUSTOMER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS STORE_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.CUSTOMER_KEY = d.CUSTOMER_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_person r_person ON t.CUSTOMER_KEY = r_person.CUSTOMER_KEY AND t.EFF_TMSTP = r_person.EFF_TMSTP
+    LEFT JOIN rel_sales_territory r_sales_territory ON t.CUSTOMER_KEY = r_sales_territory.CUSTOMER_KEY AND t.EFF_TMSTP = r_sales_territory.EFF_TMSTP
+    LEFT JOIN rel_store r_store ON t.CUSTOMER_KEY = r_store.CUSTOMER_KEY AND t.EFF_TMSTP = r_store.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.CUSTOMER_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.CUSTOMER_KEY,
+        p.customer_account_number,
+        p.PERSON_KEY,
+        p.SALES_TERRITORY_KEY,
+        p.STORE_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.CUSTOMER_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.CUSTOMER_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS CUSTOMER_KEY,
+    NULL AS customer_account_number,
+    NULL AS PERSON_KEY,
+    NULL AS SALES_TERRITORY_KEY,
+    NULL AS STORE_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/employee.sql
+++ b/uss/employee.sql
@@ -1,0 +1,163 @@
+CREATE OR REPLACE VIEW uss.employee AS
+WITH ranked AS (
+    SELECT
+        EMPLOYEE_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_STR,
+        VAL_NUM,
+        STA_TMSTP,
+        RANK() OVER (
+            PARTITION BY EMPLOYEE_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.EMPLOYEE_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: EMPLOYEE -> PERSON (TYPE_KEY=83)
+ranked_employee_person_x AS (
+    SELECT
+        EMPLOYEE_KEY,
+        EFF_TMSTP,
+        PERSON_KEY,
+        RANK() OVER (
+            PARTITION BY EMPLOYEE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.EMPLOYEE_PERSON_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 83
+),
+rel_person AS (
+    SELECT EMPLOYEE_KEY, EFF_TMSTP, PERSON_KEY
+    FROM ranked_employee_person_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT EMPLOYEE_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT EMPLOYEE_KEY, EFF_TMSTP
+    FROM rel_person
+),
+pivoted AS (
+    SELECT
+        t.EMPLOYEE_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 37 THEN d.STA_TMSTP END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_birth_date,
+        MAX(CASE WHEN d.TYPE_KEY = 27 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_current_flag,
+        MAX(CASE WHEN d.TYPE_KEY = 24 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_gender,
+        MAX(CASE WHEN d.TYPE_KEY = 23 THEN d.STA_TMSTP END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_hire_date,
+        MAX(CASE WHEN d.TYPE_KEY = 9 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_job_title,
+        MAX(CASE WHEN d.TYPE_KEY = 2 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_login_id,
+        MAX(CASE WHEN d.TYPE_KEY = 93 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_marital_status,
+        MAX(CASE WHEN d.TYPE_KEY = 106 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_national_id_number,
+        MAX(CASE WHEN d.TYPE_KEY = 85 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_salaried_flag,
+        MAX(CASE WHEN d.TYPE_KEY = 49 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_sick_leave_hours,
+        MAX(CASE WHEN d.TYPE_KEY = 13 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS employee_vacation_hours,
+        MAX(r_person.PERSON_KEY) OVER (
+            PARTITION BY t.EMPLOYEE_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PERSON_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.EMPLOYEE_KEY = d.EMPLOYEE_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_person r_person ON t.EMPLOYEE_KEY = r_person.EMPLOYEE_KEY AND t.EFF_TMSTP = r_person.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.EMPLOYEE_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.EMPLOYEE_KEY,
+        p.employee_birth_date,
+        p.employee_current_flag,
+        p.employee_gender,
+        p.employee_hire_date,
+        p.employee_job_title,
+        p.employee_login_id,
+        p.employee_marital_status,
+        p.employee_national_id_number,
+        p.employee_salaried_flag,
+        p.employee_sick_leave_hours,
+        p.employee_vacation_hours,
+        p.PERSON_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.EMPLOYEE_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.EMPLOYEE_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS EMPLOYEE_KEY,
+    NULL::timestamp AS employee_birth_date,
+    NULL AS employee_current_flag,
+    NULL AS employee_gender,
+    NULL::timestamp AS employee_hire_date,
+    NULL AS employee_job_title,
+    NULL AS employee_login_id,
+    NULL AS employee_marital_status,
+    NULL AS employee_national_id_number,
+    NULL AS employee_salaried_flag,
+    NULL::numeric AS employee_sick_leave_hours,
+    NULL::numeric AS employee_vacation_hours,
+    NULL AS PERSON_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/purchase_order.sql
+++ b/uss/purchase_order.sql
@@ -1,0 +1,166 @@
+CREATE OR REPLACE VIEW uss.purchase_order AS
+WITH ranked AS (
+    SELECT
+        PURCHASE_ORDER_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_STR,
+        VAL_NUM,
+        STA_TMSTP,
+        END_TMSTP,
+        RANK() OVER (
+            PARTITION BY PURCHASE_ORDER_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.PURCHASE_ORDER_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: PURCHASE_ORDER -> EMPLOYEE (TYPE_KEY=30)
+ranked_po_employee_x AS (
+    SELECT
+        PURCHASE_ORDER_KEY,
+        EFF_TMSTP,
+        EMPLOYEE_KEY,
+        RANK() OVER (
+            PARTITION BY PURCHASE_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.PURCHASE_ORDER_EMPLOYEE_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 30
+),
+rel_employee AS (
+    SELECT PURCHASE_ORDER_KEY, EFF_TMSTP, EMPLOYEE_KEY
+    FROM ranked_po_employee_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: PURCHASE_ORDER -> VENDOR (TYPE_KEY=12)
+ranked_po_vendor_x AS (
+    SELECT
+        PURCHASE_ORDER_KEY,
+        EFF_TMSTP,
+        VENDOR_KEY,
+        RANK() OVER (
+            PARTITION BY PURCHASE_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.PURCHASE_ORDER_VENDOR_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 12
+),
+rel_vendor AS (
+    SELECT PURCHASE_ORDER_KEY, EFF_TMSTP, VENDOR_KEY
+    FROM ranked_po_vendor_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT PURCHASE_ORDER_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT PURCHASE_ORDER_KEY, EFF_TMSTP
+    FROM rel_employee
+    UNION
+    SELECT DISTINCT PURCHASE_ORDER_KEY, EFF_TMSTP
+    FROM rel_vendor
+),
+pivoted AS (
+    SELECT
+        t.PURCHASE_ORDER_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 56 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_freight,
+        MAX(CASE WHEN d.TYPE_KEY = 98 THEN d.STA_TMSTP END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_order_date,
+        MAX(CASE WHEN d.TYPE_KEY = 32 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_revision_number,
+        MAX(CASE WHEN d.TYPE_KEY = 8 THEN d.END_TMSTP END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_ship_date,
+        MAX(CASE WHEN d.TYPE_KEY = 121 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_status,
+        MAX(CASE WHEN d.TYPE_KEY = 61 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_sub_total,
+        MAX(CASE WHEN d.TYPE_KEY = 51 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS purchase_order_tax_amt,
+        MAX(r_employee.EMPLOYEE_KEY) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS EMPLOYEE_KEY,
+        MAX(r_vendor.VENDOR_KEY) OVER (
+            PARTITION BY t.PURCHASE_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS VENDOR_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.PURCHASE_ORDER_KEY = d.PURCHASE_ORDER_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_employee r_employee ON t.PURCHASE_ORDER_KEY = r_employee.PURCHASE_ORDER_KEY AND t.EFF_TMSTP = r_employee.EFF_TMSTP
+    LEFT JOIN rel_vendor r_vendor ON t.PURCHASE_ORDER_KEY = r_vendor.PURCHASE_ORDER_KEY AND t.EFF_TMSTP = r_vendor.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.PURCHASE_ORDER_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.PURCHASE_ORDER_KEY,
+        p.purchase_order_freight,
+        p.purchase_order_order_date,
+        p.purchase_order_revision_number,
+        p.purchase_order_ship_date,
+        p.purchase_order_status,
+        p.purchase_order_sub_total,
+        p.purchase_order_tax_amt,
+        p.EMPLOYEE_KEY,
+        p.VENDOR_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.PURCHASE_ORDER_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.PURCHASE_ORDER_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS PURCHASE_ORDER_KEY,
+    NULL::numeric AS purchase_order_freight,
+    NULL::timestamp AS purchase_order_order_date,
+    NULL::numeric AS purchase_order_revision_number,
+    NULL::timestamp AS purchase_order_ship_date,
+    NULL AS purchase_order_status,
+    NULL::numeric AS purchase_order_sub_total,
+    NULL::numeric AS purchase_order_tax_amt,
+    NULL AS EMPLOYEE_KEY,
+    NULL AS VENDOR_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/sales_order.sql
+++ b/uss/sales_order.sql
@@ -1,0 +1,284 @@
+CREATE OR REPLACE VIEW uss.sales_order AS
+WITH ranked AS (
+    SELECT
+        SALES_ORDER_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_STR,
+        VAL_NUM,
+        STA_TMSTP,
+        END_TMSTP,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER -> CUSTOMER (TYPE_KEY=7)
+ranked_sales_order_customer_x AS (
+    SELECT
+        SALES_ORDER_KEY,
+        EFF_TMSTP,
+        CUSTOMER_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_CUSTOMER_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 7
+),
+rel_customer AS (
+    SELECT SALES_ORDER_KEY, EFF_TMSTP, CUSTOMER_KEY
+    FROM ranked_sales_order_customer_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER -> ADDRESS (billed_to, TYPE_KEY=189)
+ranked_sales_order_bill_address_x AS (
+    SELECT
+        SALES_ORDER_KEY,
+        EFF_TMSTP,
+        ADDRESS_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_ADDRESS_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 189
+),
+rel_bill_address AS (
+    SELECT SALES_ORDER_KEY, EFF_TMSTP, ADDRESS_KEY
+    FROM ranked_sales_order_bill_address_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER -> ADDRESS (shipped_to, TYPE_KEY=190)
+ranked_sales_order_ship_address_x AS (
+    SELECT
+        SALES_ORDER_KEY,
+        EFF_TMSTP,
+        ADDRESS_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_ADDRESS_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 190
+),
+rel_ship_address AS (
+    SELECT SALES_ORDER_KEY, EFF_TMSTP, ADDRESS_KEY
+    FROM ranked_sales_order_ship_address_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER -> SALES_PERSON (TYPE_KEY=117)
+ranked_sales_order_sales_person_x AS (
+    SELECT
+        SALES_ORDER_KEY,
+        EFF_TMSTP,
+        SALES_PERSON_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_SALES_PERSON_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 117
+),
+rel_sales_person AS (
+    SELECT SALES_ORDER_KEY, EFF_TMSTP, SALES_PERSON_KEY
+    FROM ranked_sales_order_sales_person_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER -> SALES_TERRITORY (TYPE_KEY=21)
+ranked_sales_order_sales_territory_x AS (
+    SELECT
+        SALES_ORDER_KEY,
+        EFF_TMSTP,
+        SALES_TERRITORY_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_SALES_TERRITORY_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 21
+),
+rel_sales_territory AS (
+    SELECT SALES_ORDER_KEY, EFF_TMSTP, SALES_TERRITORY_KEY
+    FROM ranked_sales_order_sales_territory_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT SALES_ORDER_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT SALES_ORDER_KEY, EFF_TMSTP
+    FROM rel_customer
+    UNION
+    SELECT DISTINCT SALES_ORDER_KEY, EFF_TMSTP
+    FROM rel_bill_address
+    UNION
+    SELECT DISTINCT SALES_ORDER_KEY, EFF_TMSTP
+    FROM rel_ship_address
+    UNION
+    SELECT DISTINCT SALES_ORDER_KEY, EFF_TMSTP
+    FROM rel_sales_person
+    UNION
+    SELECT DISTINCT SALES_ORDER_KEY, EFF_TMSTP
+    FROM rel_sales_territory
+),
+pivoted AS (
+    SELECT
+        t.SALES_ORDER_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 95 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_account_number,
+        MAX(CASE WHEN d.TYPE_KEY = 58 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_comment,
+        MAX(CASE WHEN d.TYPE_KEY = 76 THEN d.END_TMSTP END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_due_date,
+        MAX(CASE WHEN d.TYPE_KEY = 126 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_freight,
+        MAX(CASE WHEN d.TYPE_KEY = 87 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_online_order_flag,
+        MAX(CASE WHEN d.TYPE_KEY = 55 THEN d.STA_TMSTP END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_order_date,
+        MAX(CASE WHEN d.TYPE_KEY = 26 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_purchase_order_number,
+        MAX(CASE WHEN d.TYPE_KEY = 10 THEN d.END_TMSTP END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_ship_date,
+        MAX(CASE WHEN d.TYPE_KEY = 71 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_status,
+        MAX(CASE WHEN d.TYPE_KEY = 110 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_sub_total,
+        MAX(CASE WHEN d.TYPE_KEY = 17 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_tax_amt,
+        MAX(r_customer.CUSTOMER_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS CUSTOMER_KEY,
+        MAX(r_bill_address.ADDRESS_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS BILL_TO_ADDRESS_KEY,
+        MAX(r_ship_address.ADDRESS_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SHIP_TO_ADDRESS_KEY,
+        MAX(r_sales_person.SALES_PERSON_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SALES_PERSON_KEY,
+        MAX(r_sales_territory.SALES_TERRITORY_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SALES_TERRITORY_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.SALES_ORDER_KEY = d.SALES_ORDER_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_customer r_customer ON t.SALES_ORDER_KEY = r_customer.SALES_ORDER_KEY AND t.EFF_TMSTP = r_customer.EFF_TMSTP
+    LEFT JOIN rel_bill_address r_bill_address ON t.SALES_ORDER_KEY = r_bill_address.SALES_ORDER_KEY AND t.EFF_TMSTP = r_bill_address.EFF_TMSTP
+    LEFT JOIN rel_ship_address r_ship_address ON t.SALES_ORDER_KEY = r_ship_address.SALES_ORDER_KEY AND t.EFF_TMSTP = r_ship_address.EFF_TMSTP
+    LEFT JOIN rel_sales_person r_sales_person ON t.SALES_ORDER_KEY = r_sales_person.SALES_ORDER_KEY AND t.EFF_TMSTP = r_sales_person.EFF_TMSTP
+    LEFT JOIN rel_sales_territory r_sales_territory ON t.SALES_ORDER_KEY = r_sales_territory.SALES_ORDER_KEY AND t.EFF_TMSTP = r_sales_territory.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.SALES_ORDER_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.SALES_ORDER_KEY,
+        p.sales_order_account_number,
+        p.sales_order_comment,
+        p.sales_order_due_date,
+        p.sales_order_freight,
+        p.sales_order_online_order_flag,
+        p.sales_order_order_date,
+        p.sales_order_purchase_order_number,
+        p.sales_order_ship_date,
+        p.sales_order_status,
+        p.sales_order_sub_total,
+        p.sales_order_tax_amt,
+        p.CUSTOMER_KEY,
+        p.BILL_TO_ADDRESS_KEY,
+        p.SHIP_TO_ADDRESS_KEY,
+        p.SALES_PERSON_KEY,
+        p.SALES_TERRITORY_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.SALES_ORDER_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.SALES_ORDER_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS SALES_ORDER_KEY,
+    NULL AS sales_order_account_number,
+    NULL AS sales_order_comment,
+    NULL::timestamp AS sales_order_due_date,
+    NULL::numeric AS sales_order_freight,
+    NULL AS sales_order_online_order_flag,
+    NULL::timestamp AS sales_order_order_date,
+    NULL AS sales_order_purchase_order_number,
+    NULL::timestamp AS sales_order_ship_date,
+    NULL AS sales_order_status,
+    NULL::numeric AS sales_order_sub_total,
+    NULL::numeric AS sales_order_tax_amt,
+    NULL AS CUSTOMER_KEY,
+    NULL AS BILL_TO_ADDRESS_KEY,
+    NULL AS SHIP_TO_ADDRESS_KEY,
+    NULL AS SALES_PERSON_KEY,
+    NULL AS SALES_TERRITORY_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/sales_order_detail.sql
+++ b/uss/sales_order_detail.sql
@@ -1,0 +1,173 @@
+CREATE OR REPLACE VIEW uss.sales_order_detail AS
+WITH ranked AS (
+    SELECT
+        SALES_ORDER_DETAIL_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_STR,
+        VAL_NUM,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_DETAIL_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_DETAIL_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER_DETAIL -> SALES_ORDER (TYPE_KEY=48)
+ranked_sod_sales_order_x AS (
+    SELECT
+        SALES_ORDER_DETAIL_KEY,
+        EFF_TMSTP,
+        SALES_ORDER_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_DETAIL_SALES_ORDER_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 48
+),
+rel_sales_order AS (
+    SELECT SALES_ORDER_DETAIL_KEY, EFF_TMSTP, SALES_ORDER_KEY
+    FROM ranked_sod_sales_order_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER_DETAIL -> PRODUCT (TYPE_KEY=20)
+ranked_sod_product_x AS (
+    SELECT
+        SALES_ORDER_DETAIL_KEY,
+        EFF_TMSTP,
+        PRODUCT_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_DETAIL_PRODUCT_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 20
+),
+rel_product AS (
+    SELECT SALES_ORDER_DETAIL_KEY, EFF_TMSTP, PRODUCT_KEY
+    FROM ranked_sod_product_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_ORDER_DETAIL -> SPECIAL_OFFER (TYPE_KEY=3)
+ranked_sod_special_offer_x AS (
+    SELECT
+        SALES_ORDER_DETAIL_KEY,
+        EFF_TMSTP,
+        SPECIAL_OFFER_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_ORDER_DETAIL_SPECIAL_OFFER_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 3
+),
+rel_special_offer AS (
+    SELECT SALES_ORDER_DETAIL_KEY, EFF_TMSTP, SPECIAL_OFFER_KEY
+    FROM ranked_sod_special_offer_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+    FROM rel_sales_order
+    UNION
+    SELECT DISTINCT SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+    FROM rel_product
+    UNION
+    SELECT DISTINCT SALES_ORDER_DETAIL_KEY, EFF_TMSTP
+    FROM rel_special_offer
+),
+pivoted AS (
+    SELECT
+        t.SALES_ORDER_DETAIL_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 131 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_detail_carrier_tracking_number,
+        MAX(CASE WHEN d.TYPE_KEY = 60 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_detail_order_qty,
+        MAX(CASE WHEN d.TYPE_KEY = 129 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_detail_unit_price,
+        MAX(CASE WHEN d.TYPE_KEY = 36 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_order_detail_unit_price_discount,
+        MAX(r_sales_order.SALES_ORDER_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SALES_ORDER_KEY,
+        MAX(r_product.PRODUCT_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PRODUCT_KEY,
+        MAX(r_special_offer.SPECIAL_OFFER_KEY) OVER (
+            PARTITION BY t.SALES_ORDER_DETAIL_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SPECIAL_OFFER_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.SALES_ORDER_DETAIL_KEY = d.SALES_ORDER_DETAIL_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_sales_order r_sales_order ON t.SALES_ORDER_DETAIL_KEY = r_sales_order.SALES_ORDER_DETAIL_KEY AND t.EFF_TMSTP = r_sales_order.EFF_TMSTP
+    LEFT JOIN rel_product r_product ON t.SALES_ORDER_DETAIL_KEY = r_product.SALES_ORDER_DETAIL_KEY AND t.EFF_TMSTP = r_product.EFF_TMSTP
+    LEFT JOIN rel_special_offer r_special_offer ON t.SALES_ORDER_DETAIL_KEY = r_special_offer.SALES_ORDER_DETAIL_KEY AND t.EFF_TMSTP = r_special_offer.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.SALES_ORDER_DETAIL_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.SALES_ORDER_DETAIL_KEY,
+        p.sales_order_detail_carrier_tracking_number,
+        p.sales_order_detail_order_qty,
+        p.sales_order_detail_unit_price,
+        p.sales_order_detail_unit_price_discount,
+        p.SALES_ORDER_KEY,
+        p.PRODUCT_KEY,
+        p.SPECIAL_OFFER_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.SALES_ORDER_DETAIL_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.SALES_ORDER_DETAIL_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS SALES_ORDER_DETAIL_KEY,
+    NULL AS sales_order_detail_carrier_tracking_number,
+    NULL::numeric AS sales_order_detail_order_qty,
+    NULL::numeric AS sales_order_detail_unit_price,
+    NULL::numeric AS sales_order_detail_unit_price_discount,
+    NULL AS SALES_ORDER_KEY,
+    NULL AS PRODUCT_KEY,
+    NULL AS SPECIAL_OFFER_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/sales_person.sql
+++ b/uss/sales_person.sql
@@ -1,0 +1,149 @@
+CREATE OR REPLACE VIEW uss.sales_person AS
+WITH ranked AS (
+    SELECT
+        SALES_PERSON_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_NUM,
+        RANK() OVER (
+            PARTITION BY SALES_PERSON_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_PERSON_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: SALES_PERSON -> EMPLOYEE (TYPE_KEY=62)
+ranked_sales_person_employee_x AS (
+    SELECT
+        SALES_PERSON_KEY,
+        EFF_TMSTP,
+        EMPLOYEE_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_PERSON_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_PERSON_EMPLOYEE_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 62
+),
+rel_employee AS (
+    SELECT SALES_PERSON_KEY, EFF_TMSTP, EMPLOYEE_KEY
+    FROM ranked_sales_person_employee_x
+    WHERE rnk = 1
+),
+-- Resolve relationships: SALES_PERSON -> SALES_TERRITORY (TYPE_KEY=66)
+ranked_sales_person_sales_territory_x AS (
+    SELECT
+        SALES_PERSON_KEY,
+        EFF_TMSTP,
+        SALES_TERRITORY_KEY,
+        RANK() OVER (
+            PARTITION BY SALES_PERSON_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.SALES_PERSON_SALES_TERRITORY_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 66
+),
+rel_sales_territory AS (
+    SELECT SALES_PERSON_KEY, EFF_TMSTP, SALES_TERRITORY_KEY
+    FROM ranked_sales_person_sales_territory_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT SALES_PERSON_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT SALES_PERSON_KEY, EFF_TMSTP
+    FROM rel_employee
+    UNION
+    SELECT DISTINCT SALES_PERSON_KEY, EFF_TMSTP
+    FROM rel_sales_territory
+),
+pivoted AS (
+    SELECT
+        t.SALES_PERSON_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 54 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_person_bonus,
+        MAX(CASE WHEN d.TYPE_KEY = 105 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_person_commission_pct,
+        MAX(CASE WHEN d.TYPE_KEY = 16 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_person_sales_last_year,
+        MAX(CASE WHEN d.TYPE_KEY = 5 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_person_sales_quota,
+        MAX(CASE WHEN d.TYPE_KEY = 88 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS sales_person_sales_ytd,
+        MAX(r_employee.EMPLOYEE_KEY) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS EMPLOYEE_KEY,
+        MAX(r_sales_territory.SALES_TERRITORY_KEY) OVER (
+            PARTITION BY t.SALES_PERSON_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS SALES_TERRITORY_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.SALES_PERSON_KEY = d.SALES_PERSON_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_employee r_employee ON t.SALES_PERSON_KEY = r_employee.SALES_PERSON_KEY AND t.EFF_TMSTP = r_employee.EFF_TMSTP
+    LEFT JOIN rel_sales_territory r_sales_territory ON t.SALES_PERSON_KEY = r_sales_territory.SALES_PERSON_KEY AND t.EFF_TMSTP = r_sales_territory.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.SALES_PERSON_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.SALES_PERSON_KEY,
+        p.sales_person_bonus,
+        p.sales_person_commission_pct,
+        p.sales_person_sales_last_year,
+        p.sales_person_sales_quota,
+        p.sales_person_sales_ytd,
+        p.EMPLOYEE_KEY,
+        p.SALES_TERRITORY_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.SALES_PERSON_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.SALES_PERSON_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS SALES_PERSON_KEY,
+    NULL::numeric AS sales_person_bonus,
+    NULL::numeric AS sales_person_commission_pct,
+    NULL::numeric AS sales_person_sales_last_year,
+    NULL::numeric AS sales_person_sales_quota,
+    NULL::numeric AS sales_person_sales_ytd,
+    NULL AS EMPLOYEE_KEY,
+    NULL AS SALES_TERRITORY_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/vendor.sql
+++ b/uss/vendor.sql
@@ -1,0 +1,120 @@
+CREATE OR REPLACE VIEW uss.vendor AS
+WITH ranked AS (
+    SELECT
+        VENDOR_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_STR,
+        VAL_NUM,
+        RANK() OVER (
+            PARTITION BY VENDOR_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.VENDOR_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: VENDOR -> PERSON (TYPE_KEY=91)
+ranked_vendor_person_x AS (
+    SELECT
+        VENDOR_KEY,
+        EFF_TMSTP,
+        PERSON_KEY,
+        RANK() OVER (
+            PARTITION BY VENDOR_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.VENDOR_PERSON_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 91
+),
+rel_person AS (
+    SELECT VENDOR_KEY, EFF_TMSTP, PERSON_KEY
+    FROM ranked_vendor_person_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT VENDOR_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT VENDOR_KEY, EFF_TMSTP
+    FROM rel_person
+),
+pivoted AS (
+    SELECT
+        t.VENDOR_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 99 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.VENDOR_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS vendor_account_number,
+        MAX(CASE WHEN d.TYPE_KEY = 86 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.VENDOR_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS vendor_active_flag,
+        MAX(CASE WHEN d.TYPE_KEY = 70 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.VENDOR_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS vendor_credit_rating,
+        MAX(CASE WHEN d.TYPE_KEY = 46 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.VENDOR_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS vendor_name,
+        MAX(CASE WHEN d.TYPE_KEY = 84 THEN d.VAL_STR END) OVER (
+            PARTITION BY t.VENDOR_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS vendor_preferred_status,
+        MAX(r_person.PERSON_KEY) OVER (
+            PARTITION BY t.VENDOR_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PERSON_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.VENDOR_KEY = d.VENDOR_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_person r_person ON t.VENDOR_KEY = r_person.VENDOR_KEY AND t.EFF_TMSTP = r_person.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.VENDOR_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.VENDOR_KEY,
+        p.vendor_account_number,
+        p.vendor_active_flag,
+        p.vendor_credit_rating,
+        p.vendor_name,
+        p.vendor_preferred_status,
+        p.PERSON_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.VENDOR_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.VENDOR_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS VENDOR_KEY,
+    NULL AS vendor_account_number,
+    NULL AS vendor_active_flag,
+    NULL::numeric AS vendor_credit_rating,
+    NULL AS vendor_name,
+    NULL AS vendor_preferred_status,
+    NULL AS PERSON_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;

--- a/uss/work_order.sql
+++ b/uss/work_order.sql
@@ -1,0 +1,121 @@
+CREATE OR REPLACE VIEW uss.work_order AS
+WITH ranked AS (
+    SELECT
+        WORK_ORDER_KEY,
+        TYPE_KEY,
+        EFF_TMSTP,
+        VAL_NUM,
+        STA_TMSTP,
+        END_TMSTP,
+        RANK() OVER (
+            PARTITION BY WORK_ORDER_KEY, TYPE_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.WORK_ORDER_DESC
+),
+deduped AS (
+    SELECT * FROM ranked WHERE rnk = 1
+),
+-- Resolve relationships: WORK_ORDER -> PRODUCT (TYPE_KEY=74)
+ranked_wo_product_x AS (
+    SELECT
+        WORK_ORDER_KEY,
+        EFF_TMSTP,
+        PRODUCT_KEY,
+        RANK() OVER (
+            PARTITION BY WORK_ORDER_KEY, EFF_TMSTP
+            ORDER BY VER_TMSTP DESC
+        ) AS rnk
+    FROM daana_dw.WORK_ORDER_PRODUCT_X
+    WHERE ROW_ST = 'Y'
+      AND TYPE_KEY = 74
+),
+rel_product AS (
+    SELECT WORK_ORDER_KEY, EFF_TMSTP, PRODUCT_KEY
+    FROM ranked_wo_product_x
+    WHERE rnk = 1
+),
+timeline AS (
+    SELECT DISTINCT WORK_ORDER_KEY, EFF_TMSTP
+    FROM deduped
+    UNION
+    SELECT DISTINCT WORK_ORDER_KEY, EFF_TMSTP
+    FROM rel_product
+),
+pivoted AS (
+    SELECT
+        t.WORK_ORDER_KEY,
+        t.EFF_TMSTP,
+        MAX(CASE WHEN d.TYPE_KEY = 52 THEN d.END_TMSTP END) OVER (
+            PARTITION BY t.WORK_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS work_order_due_date,
+        MAX(CASE WHEN d.TYPE_KEY = 29 THEN d.END_TMSTP END) OVER (
+            PARTITION BY t.WORK_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS work_order_end_date,
+        MAX(CASE WHEN d.TYPE_KEY = 4 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.WORK_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS work_order_order_qty,
+        MAX(CASE WHEN d.TYPE_KEY = 73 THEN d.VAL_NUM END) OVER (
+            PARTITION BY t.WORK_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS work_order_scrapped_qty,
+        MAX(CASE WHEN d.TYPE_KEY = 128 THEN d.STA_TMSTP END) OVER (
+            PARTITION BY t.WORK_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS work_order_start_date,
+        MAX(r_product.PRODUCT_KEY) OVER (
+            PARTITION BY t.WORK_ORDER_KEY
+            ORDER BY t.EFF_TMSTP
+            RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS PRODUCT_KEY
+    FROM timeline t
+    LEFT JOIN deduped d ON t.WORK_ORDER_KEY = d.WORK_ORDER_KEY AND t.EFF_TMSTP = d.EFF_TMSTP
+    LEFT JOIN rel_product r_product ON t.WORK_ORDER_KEY = r_product.WORK_ORDER_KEY AND t.EFF_TMSTP = r_product.EFF_TMSTP
+),
+pivoted_deduped AS (
+    SELECT DISTINCT * FROM pivoted
+),
+peripheral_final AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY p.WORK_ORDER_KEY, p.EFF_TMSTP) AS _peripheral_key,
+        p.WORK_ORDER_KEY,
+        p.work_order_due_date,
+        p.work_order_end_date,
+        p.work_order_order_qty,
+        p.work_order_scrapped_qty,
+        p.work_order_start_date,
+        p.PRODUCT_KEY,
+        CASE
+            WHEN ROW_NUMBER() OVER (PARTITION BY p.WORK_ORDER_KEY ORDER BY p.EFF_TMSTP) = 1
+            THEN '1900-01-01'::timestamp
+            ELSE p.EFF_TMSTP
+        END AS effective_from,
+        COALESCE(
+            LEAD(p.EFF_TMSTP) OVER (PARTITION BY p.WORK_ORDER_KEY ORDER BY p.EFF_TMSTP),
+            '9999-12-31'::timestamp
+        ) AS effective_to
+    FROM pivoted_deduped p
+)
+SELECT * FROM peripheral_final
+
+UNION ALL
+
+SELECT
+    -1 AS _peripheral_key,
+    'UNKNOWN' AS WORK_ORDER_KEY,
+    NULL::timestamp AS work_order_due_date,
+    NULL::timestamp AS work_order_end_date,
+    NULL::numeric AS work_order_order_qty,
+    NULL::numeric AS work_order_scrapped_qty,
+    NULL::timestamp AS work_order_start_date,
+    NULL AS PRODUCT_KEY,
+    '1900-01-01'::timestamp AS effective_from,
+    '9999-12-31'::timestamp AS effective_to;


### PR DESCRIPTION
## Summary

Closes #55

- Relationship CTEs in 8 peripheral views now use Type 2 dedup (`PARTITION BY entity_KEY, EFF_TMSTP`) instead of snapshot dedup, with carry-forward windows in the pivoted CTE
- Relationship `EFF_TMSTP` values merge into the timeline spine so every change point (descriptor or relationship) produces a peripheral row
- Updated `uss-patterns.md` to document the peripheral-specific Type 2 relationship pattern alongside the existing bridge snapshot pattern

## Affected peripherals

`customer`, `employee`, `sales_person`, `vendor`, `sales_order`, `sales_order_detail`, `purchase_order`, `work_order`

## Test plan

- [ ] Verify peripheral SQL parses without errors against a Focal-bootstrapped DW
- [ ] Confirm relationship FKs reflect historical state (not latest-only) at each `effective_from` point
- [ ] Confirm bridge point-in-time joins still resolve correctly against updated peripheral `effective_from`/`effective_to` ranges
- [ ] Verify `store.sql` and `_bridge.sql` are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)