### PR TITLE
chore: apply claude-template project rules

### DIFF
--- a/.claude/rules/adr.md
+++ b/.claude/rules/adr.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records (ADR)
+
+## Format
+
+Each feature gets one ADR file in `docs/superpowers/adr/`, named `<date>-<feature-slug>-adr.md` (matching the spec/plan naming convention). Decisions are appended as numbered entries:
+
+### Template
+
+    ## ADR-NNN: <Title>
+
+    - **Date:** YYYY-MM-DD
+    - **Status:** accepted | superseded by ADR-NNN
+
+    ### Context
+    What prompted the decision.
+
+    ### Options Considered
+    - **Option A** — trade-offs
+    - **Option B** — trade-offs
+
+    ### Decision
+    What was chosen and why.
+
+    ### Consequences
+    What this means going forward.
+
+## Conventions
+
+- Numbering is sequential within the feature file (ADR-001, ADR-002, ...). There is no global numbering.
+- Discovery is convention-based: use the `*-adr.md` naming pattern and search. There is no index file.
+
+## Rules
+
+- NEVER modify an existing ADR entry. Append a new entry that supersedes it.
+- NEVER create an ADR file without following the naming convention `<date>-<feature-slug>-adr.md`.
+- NEVER omit "Options Considered" — if there were no alternatives, it is not a decision worth recording.
+- NEVER log trivial implementation details (variable names, formatting). Only log choices between meaningful alternatives.

--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,0 +1,45 @@
+# Conventional Commits 1.0.0
+
+Source: https://www.conventionalcommits.org/en/v1.0.0/
+
+## Specification
+
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
+2. The type `feat` MUST be used when a commit adds a new feature to your application or library.
+3. The type `fix` MUST be used when a commit represents a bug fix for your application.
+4. A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+5. A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+7. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+9. A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., _BREAKING CHANGE: environment variables now take precedence over config files_.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `!` immediately before the `:`. If `!` is used, `BREAKING CHANGE:` MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs._
+15. The units of information that make up Conventional Commits MUST NOT be treated as case-sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Common Types
+
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation only changes
+- `style`: Changes that do not affect the meaning of the code (white-space, formatting, etc.)
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `perf`: A code change that improves performance
+- `test`: Adding missing tests or correcting existing tests
+- `build`: Changes that affect the build system or external dependencies
+- `ci`: Changes to CI configuration files and scripts
+- `chore`: Other changes that don't modify src or test files
+
+## Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```

--- a/.claude/rules/functional-programming.md
+++ b/.claude/rules/functional-programming.md
@@ -1,0 +1,7 @@
+# Functional Programming
+
+- NEVER use classes when a plain function or module of functions will do. If a framework requires a class, keep it as a thin wrapper and extract all logic into pure functions.
+- NEVER use mutable state. Prefer `const`, `readonly`, frozen objects, and immutable data structures.
+- NEVER use inheritance. Use composition and higher-order functions instead.
+- NEVER write methods with side effects without isolating them at the boundary. Keep core logic as pure functions.
+- NEVER use imperative loops (`for`, `while`) when a declarative alternative exists (`map`, `filter`, `reduce`, `flatMap`, etc.).

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,11 @@
+# Git Workflow
+
+- NEVER commit directly to main.
+- NEVER use non-conventional commit formats. See .claude/rules/conventional-commits.md
+- NEVER leave commits unpushed.
+- NEVER use raw git for remote operations when a CLI is available for the remote platform (e.g., `gh` for GitHub, `az repos` for Azure DevOps).
+- NEVER rely on global git email. Before committing, check `git config --local user.email`. If not set, prompt the user.
+- NEVER open PRs as ready. Always open as draft (e.g., `gh pr create --draft`).
+- NEVER enable auto-merge on draft PRs. Enable auto-merge only after the PR is marked as ready (e.g., `gh pr ready` then `gh pr merge --auto --merge`).
+- NEVER enable auto-merge on PRs from external contributors. Only repo admins/owners may use auto-merge.
+- NEVER use squash or rebase merges. Always use regular merge commits (`--merge`).

--- a/.claude/rules/repo-setup.md
+++ b/.claude/rules/repo-setup.md
@@ -1,0 +1,5 @@
+# Repo Setup
+
+- NEVER leave the default branch unprotected. Require PRs (no direct pushes) with at least one approving review. Admins may bypass.
+- NEVER leave auto-merge disabled on a new repo.
+- NEVER leave auto-delete of merged branches disabled on a new repo.

--- a/.claude/rules/rule-style.md
+++ b/.claude/rules/rule-style.md
@@ -1,0 +1,3 @@
+# Rule Style
+
+- NEVER write rules as "do X". Always phrase rules as "NEVER do Y" to clearly define what to avoid.

--- a/.claude/rules/superpowers.md
+++ b/.claude/rules/superpowers.md
@@ -5,3 +5,5 @@
 - NEVER dispatch parallel subagents into the same worktree — they will conflict on git operations.
 - NEVER use `isolation: "worktree"` when the parent is on a non-main branch — it branches from main, not the parent branch. Create worktrees manually from the current branch (via `using-git-worktrees`) instead.
 - NEVER write plans, specs, or implementation files before setting up an isolated worktree.
+- NEVER finish brainstorming without logging design decisions (approach chosen, alternatives rejected) to the feature's `*-adr.md` file in `docs/superpowers/adr/`.
+- NEVER make an implementation decision between competing alternatives (libraries, patterns, architectures) without logging it to the feature's `*-adr.md` file in `docs/superpowers/adr/`.

--- a/.claude/rules/superpowers.md
+++ b/.claude/rules/superpowers.md
@@ -1,0 +1,7 @@
+# Superpowers
+
+- NEVER store plans and design specs in `docs/plans/`. Store plans in `docs/superpowers/plans/` and design specs in `docs/superpowers/specs/`.
+- NEVER default plans to sequential execution. Optimize for parallelization.
+- NEVER dispatch parallel subagents into the same worktree — they will conflict on git operations.
+- NEVER use `isolation: "worktree"` when the parent is on a non-main branch — it branches from main, not the parent branch. Create worktrees manually from the current branch (via `using-git-worktrees`) instead.
+- NEVER write plans, specs, or implementation files before setting up an isolated worktree.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Claude Code - personal overrides
+CLAUDE.local.md
+.claude/settings.local.json
+
 .claude/worktrees/
 .claude/worktrees
 .worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,3 @@
-# Rules
-
-- NEVER write rules as "do X". Always phrase rules as "NEVER do Y" to clearly define what to avoid.
-
-# Git Workflow
-
-- NEVER commit directly to main.
-- NEVER use non-conventional commit formats. See .claude/rules/conventional-commits.md
-- NEVER leave commits unpushed.
-- NEVER use raw git for remote operations when a CLI is available for the remote platform (e.g., `gh` for GitHub, `az repos` for Azure DevOps).
-- NEVER rely on global git email. Before committing, check `git config --local user.email`. If not set, prompt the user.
-- NEVER open PRs as ready. Always open as draft (e.g., `gh pr create --draft`).
-- NEVER enable auto-merge on draft PRs. Enable auto-merge only after the PR is marked as ready (e.g., `gh pr ready` then `gh pr merge --auto --merge`).
-- NEVER enable auto-merge on PRs from external contributors. Only repo admins/owners may use auto-merge.
-- NEVER use squash or rebase merges. Always use regular merge commits (`--merge`).
-
-# Repo Setup
-
-- NEVER leave the default branch unprotected. Require PRs (no direct pushes) with at least one approving review. Admins may bypass.
-- NEVER leave auto-merge disabled on a new repo.
-- NEVER leave auto-delete of merged branches disabled on a new repo.
-
-# Superpowers
-
-- NEVER store plans and design specs in `docs/plans/`. Store plans in `docs/superpowers/plans/` and design specs in `docs/superpowers/specs/`.
-- NEVER default plans to sequential execution. Optimize for parallelization.
-- NEVER dispatch parallel subagents into the same worktree. Each subagent MUST work in its own isolated worktree (via `using-git-worktrees`).
-- NEVER use `isolation: "worktree"` when the parent is on a non-main branch — it branches from main, not the parent branch. Create worktrees manually from the current branch (via `using-git-worktrees`) instead.
-
----
-
 # daana-modeler
 
 daana-modeler is a Claude Code plugin for the Daana data platform. It provides six skills for building, querying, and transforming DMDL data models.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,34 @@
+# Rules
+
+- NEVER write rules as "do X". Always phrase rules as "NEVER do Y" to clearly define what to avoid.
+
+# Git Workflow
+
+- NEVER commit directly to main.
+- NEVER use non-conventional commit formats. See .claude/rules/conventional-commits.md
+- NEVER leave commits unpushed.
+- NEVER use raw git for remote operations when a CLI is available for the remote platform (e.g., `gh` for GitHub, `az repos` for Azure DevOps).
+- NEVER rely on global git email. Before committing, check `git config --local user.email`. If not set, prompt the user.
+- NEVER open PRs as ready. Always open as draft (e.g., `gh pr create --draft`).
+- NEVER enable auto-merge on draft PRs. Enable auto-merge only after the PR is marked as ready (e.g., `gh pr ready` then `gh pr merge --auto --merge`).
+- NEVER enable auto-merge on PRs from external contributors. Only repo admins/owners may use auto-merge.
+- NEVER use squash or rebase merges. Always use regular merge commits (`--merge`).
+
+# Repo Setup
+
+- NEVER leave the default branch unprotected. Require PRs (no direct pushes) with at least one approving review. Admins may bypass.
+- NEVER leave auto-merge disabled on a new repo.
+- NEVER leave auto-delete of merged branches disabled on a new repo.
+
+# Superpowers
+
+- NEVER store plans and design specs in `docs/plans/`. Store plans in `docs/superpowers/plans/` and design specs in `docs/superpowers/specs/`.
+- NEVER default plans to sequential execution. Optimize for parallelization.
+- NEVER dispatch parallel subagents into the same worktree. Each subagent MUST work in its own isolated worktree (via `using-git-worktrees`).
+- NEVER use `isolation: "worktree"` when the parent is on a non-main branch — it branches from main, not the parent branch. Create worktrees manually from the current branch (via `using-git-worktrees`) instead.
+
+---
+
 # daana-modeler
 
 daana-modeler is a Claude Code plugin for the Daana data platform. It provides six skills for building, querying, and transforming DMDL data models.


### PR DESCRIPTION
## Summary
- Apply `mattiasthalen/claude-template` to project-level `CLAUDE.md` (rules, git workflow, repo setup, superpowers)
- Add `.claude/rules/conventional-commits.md` (replaces global `~/.claude/CONVENTIONAL-COMMITS.md`)
- Add `CLAUDE.local.md` and `.claude/settings.local.json` to `.gitignore`

## Test plan
- [ ] Verify `CLAUDE.md` rules load correctly in new Claude Code sessions
- [ ] Verify conventional commits reference resolves from `.claude/rules/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)